### PR TITLE
Add Vessel-ETA availability monitoring

### DIFF
--- a/grafana/dashboards/dashboard-apt.json
+++ b/grafana/dashboards/dashboard-apt.json
@@ -209,10 +209,10 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "kube_deployment_status_replicas_available{deployment=\"apt-production\"}",
+          "expr": "kube_deployment_status_replicas_available{deployment=~\"(.*apt-production)|(.*vessel-eta-production)\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "Available deployment replicas",
+          "legendFormat": "{{deployment}}",
           "refId": "B"
         }
       ],
@@ -321,6 +321,6 @@
   "timezone": "browser",
   "title": "APT",
   "uid": "_jbWHWy7z",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }


### PR DESCRIPTION
Adds the k8s availability of the Vessel-ETA app to the APT dashboard.

The Vessel-ETA app produces departure events on Kafka, based on vessel GPS coordinates.

It will now be added to a graph of how many available replicas are running in K8s, should always be >= 1.

Alerts when/if it drops to 0 to follow in separate PR.