### PR TITLE
sum by deployment to group pods together

### DIFF
--- a/grafana/dashboards/dashboard-apt.json
+++ b/grafana/dashboards/dashboard-apt.json
@@ -21,7 +21,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -209,7 +208,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "kube_deployment_status_replicas_available{deployment=~\"(.*apt-production)|(.*vessel-eta-production)\"}",
+          "expr": "sum by(deployment)(kube_deployment_status_replicas_available{deployment=~\"(.*apt-production)|(.*vessel-eta-production)\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{deployment}}",
@@ -321,6 +320,6 @@
   "timezone": "browser",
   "title": "APT",
   "uid": "_jbWHWy7z",
-  "version": 5,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Use sum by()() to group pods in deployment together. I added this because I don't care which pod is running, as long as one is running.

Before:
![image](https://user-images.githubusercontent.com/41419288/161054464-23c9dd9d-c091-49d3-b14d-5bd812051765.png)

After:
![image](https://user-images.githubusercontent.com/41419288/161054525-9848a4ac-572a-42d9-a78f-87ade1d670f0.png)
