### PR TITLE
F/include postgres datasource

### DIFF
--- a/README-dfds-data.md
+++ b/README-dfds-data.md
@@ -23,6 +23,14 @@ and they should be persisted in k8s this way. The JSON dashboards are converted 
 [powershell script](./grafana/Convert-JSONToConfigmap.ps1), and deployed using
 [azure pipelines](./azure-pipelines.yml).
 
+## Adding Data Source connection for postgres
+
+To include a data source connection to a postgres database in the grafana deployment you should
+include the datasource in [datasource.yaml](./grafana/configmaps/datasource.yaml). See 
+`Postgres-Overdue` as inspiration. The connection requires the postgres database url and the
+username and password (read-only user recommended) which are defined in the ADO library
+`grafana-postgres-datasource`. More information can be found in https://grafana.com/docs/grafana/latest/datasources/postgres/
+
 ### Naming conventions
 
 Please name your dashboard `dashboard-<name>.json`, where `<name>` is some name you come up with (no

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,8 +10,24 @@ trigger:
 
 pool:
   vmImage: 'ubuntu-latest'
-
+  variables:
+    # all variable in the group library are loaded in the pipeline environment
+   - group: grafana-postgres-datasource
 steps:
+  - task: replacetokens@3
+    # Using replace tokens for the postgres data source conexions 
+    inputs:
+      rootDirectory: "$(System.DefaultWorkingDirectory)/grafana/configmaps"
+      targetFiles: "datasource.yaml"
+      encoding: "auto"
+      writeBOM: true
+      actionOnMissing: "fail"
+      keepToken: false
+      tokenPrefix: "$("
+      tokenSuffix: ")"
+      useLegacyPattern: false
+      enableTransforms: false
+      enableTelemetry: false
   - task: PowerShell@2
     displayName: Converting json dashboards to configmaps
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,10 @@ trigger:
 
 pool:
   vmImage: 'ubuntu-latest'
-  variables:
-    # all variable in the group library are loaded in the pipeline environment
-   - group: grafana-postgres-datasource
+  
+variables:
+  # all variable in the group library are loaded in the pipeline environment
+  - group: grafana-postgres-datasource
 steps:
   - task: replacetokens@3
     # Using replace tokens for the postgres data source conexions 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ trigger:
 
 pool:
   vmImage: 'ubuntu-latest'
-  
+
 variables:
   # all variable in the group library are loaded in the pipeline environment
   - group: grafana-postgres-datasource
@@ -22,7 +22,7 @@ steps:
       targetFiles: "datasource.yaml"
       encoding: "auto"
       writeBOM: true
-      actionOnMissing: "fail"
+      actionOnMissing: "warn"
       keepToken: false
       tokenPrefix: "$("
       tokenSuffix: ")"

--- a/grafana/configmaps/datasource.yaml
+++ b/grafana/configmaps/datasource.yaml
@@ -16,7 +16,7 @@ data:
       secureJsonData:
         password: $(OVERDUEFORECAST_PASSWORD)
       jsonData:
-        sslmode: "disable" # disable/require/verify-ca/verify-full
+        sslmode: "require" # disable/require/verify-ca/verify-full
         maxOpenConns: 0         
         maxIdleConns: 2         
         connMaxLifetime: 14400  

--- a/grafana/configmaps/datasource.yaml
+++ b/grafana/configmaps/datasource.yaml
@@ -13,7 +13,7 @@ data:
       # this is the relative url
       url: db
       database: overdueforecast
-      user: $(TEST_VARIABLE)
+      user: $(OVERDUEFORECAST_USER)
       secureJsonData:
         password: "docker"
       jsonData:

--- a/grafana/configmaps/datasource.yaml
+++ b/grafana/configmaps/datasource.yaml
@@ -10,12 +10,11 @@ data:
       isDefault: true
     - name: Postgres-Overdue
       type: postgres
-      # this is the relative url
-      url: db
+      url: $(OVERDUEFORECAST_POSTGRES_URL)
       database: overdueforecast
       user: $(OVERDUEFORECAST_USER)
       secureJsonData:
-        password: "docker"
+        password: $(OVERDUEFORECAST_PASSWORD)
       jsonData:
         sslmode: "disable" # disable/require/verify-ca/verify-full
         maxOpenConns: 0         

--- a/grafana/configmaps/datasource.yaml
+++ b/grafana/configmaps/datasource.yaml
@@ -8,6 +8,21 @@ data:
       url: http://monitoring-kube-prometheus-prometheus.monitoring:9090
       access: proxy
       isDefault: true
+    - name: Postgres-Overdue
+      type: postgres
+      # this is the relative url
+      url: db
+      database: overdueforecast
+      user: $(TEST_VARIABLE)
+      secureJsonData:
+        password: "docker"
+      jsonData:
+        sslmode: "disable" # disable/require/verify-ca/verify-full
+        maxOpenConns: 0         
+        maxIdleConns: 2         
+        connMaxLifetime: 14400  
+        postgresVersion: 13
+        timescaledb: false
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
Including Postgres data source connection to grafana deployment.

Motivation:
Combining Prometheus metrics and RDS in grafana could have a lot of potential for monitoring